### PR TITLE
Fix test for M1 processor due to different page-size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ libc = "0.2"
 lmdb-rkv-sys = { path = "./lmdb-sys" }
 
 [dev-dependencies]
-rand = "0.4"
+rand = "0.8"
 tempdir = "0.3"
-page_size = "0.5.0"
+page_size = "0.5"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ members = [
 bitflags = "1"
 byteorder = "1"
 libc = "0.2"
-page_size = "0.5.0"
 
 # In order to ensure that we test lmdb-rkv in CI against the in-tree version
 # of lmdb-rkv-sys, we specify the dependency as a path here.
@@ -44,6 +43,7 @@ lmdb-rkv-sys = { path = "./lmdb-sys" }
 [dev-dependencies]
 rand = "0.4"
 tempdir = "0.3"
+page_size = "0.5.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
 bitflags = "1"
 byteorder = "1"
 libc = "0.2"
+page_size = "0.5.0"
 
 # In order to ensure that we test lmdb-rkv in CI against the in-tree version
 # of lmdb-rkv-sys, we specify the dependency as a path here.

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -589,7 +589,7 @@ mod test {
 
         // Stats should be empty initially.
         let stat = env.stat().unwrap();
-        assert_eq!(stat.page_size(), 4096);
+        assert!(stat.page_size() == page_size::get() as u32);
         assert_eq!(stat.depth(), 0);
         assert_eq!(stat.branch_pages(), 0);
         assert_eq!(stat.leaf_pages(), 0);
@@ -609,7 +609,7 @@ mod test {
 
         // Stats should now reflect inserted values.
         let stat = env.stat().unwrap();
-        assert_eq!(stat.page_size(), 4096);
+        assert!(stat.page_size() == 4096 || stat.page_size() == 16384); // Covers both M1 computers and others
         assert_eq!(stat.depth(), 1);
         assert_eq!(stat.branch_pages(), 0);
         assert_eq!(stat.leaf_pages(), 1);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -609,7 +609,7 @@ mod test {
 
         // Stats should now reflect inserted values.
         let stat = env.stat().unwrap();
-        assert!(stat.page_size() == 4096 || stat.page_size() == 16384); // Covers both M1 computers and others
+        assert_eq!(stat.page_size(), page_size::get() as u32);
         assert_eq!(stat.depth(), 1);
         assert_eq!(stat.branch_pages(), 0);
         assert_eq!(stat.leaf_pages(), 1);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -589,7 +589,7 @@ mod test {
 
         // Stats should be empty initially.
         let stat = env.stat().unwrap();
-        assert!(stat.page_size() == page_size::get() as u32);
+        assert_eq!(stat.page_size(), page_size::get() as u32);
         assert_eq!(stat.depth(), 0);
         assert_eq!(stat.branch_pages(), 0);
         assert_eq!(stat.leaf_pages(), 0);


### PR DESCRIPTION
M1 page size is 16384 bytes instead of 4096 bytes. So here we use a library to get the proper number instead of using the widely-known default of 4096 for decades.

A lesson is to be learned here: Things change 😄 