### PR TITLE
Auto-resize implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ bitflags = "1"
 byteorder = "1"
 libc = "0.2"
 fs4 = { version = "0.6", features = ["sync"] }
+rm_rf = "0.6"
 
 # In order to ensure that we test lmdb-rkv in CI against the in-tree version
 # of lmdb-rkv-sys, we specify the dependency as a path here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lmdb-mintlayer"
-version = "0.15.4"
+version = "0.16.0"
 license = "Apache-2.0"
 description = "Idiomatic and safe LMDB wrapper."
 homepage = "https://github.com/mozilla/lmdb-rs-mintlayer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
 bitflags = "1"
 byteorder = "1"
 libc = "0.2"
+fs4 = { version = "0.6", features = ["sync"] }
 
 # In order to ensure that we test lmdb-rkv in CI against the in-tree version
 # of lmdb-rkv-sys, we specify the dependency as a path here.

--- a/benches/transaction.rs
+++ b/benches/transaction.rs
@@ -14,9 +14,7 @@ use lmdb::{
     Transaction,
     WriteFlags,
 };
-use rand::{
-    XorShiftRng,
-};
+use rand::{SeedableRng, seq::SliceRandom};
 use std::ptr;
 use test::{
     black_box,
@@ -32,7 +30,7 @@ fn bench_get_rand(b: &mut Bencher) {
     let txn = env.begin_ro_txn().unwrap();
 
     let mut keys: Vec<String> = (0..n).map(get_key).collect();
-    XorShiftRng::new_unseeded().shuffle(&mut keys[..]);
+    keys.shuffle(&mut rand::rngs::StdRng::from_entropy());
 
     b.iter(|| {
         let mut i = 0usize;
@@ -51,7 +49,7 @@ fn bench_get_rand_raw(b: &mut Bencher) {
     let _txn = env.begin_ro_txn().unwrap();
 
     let mut keys: Vec<String> = (0..n).map(get_key).collect();
-    XorShiftRng::new_unseeded().shuffle(&mut keys[..]);
+    keys.shuffle(&mut rand::rngs::StdRng::from_entropy());
 
     let dbi = db.dbi();
     let txn = _txn.txn();
@@ -86,7 +84,7 @@ fn bench_put_rand(b: &mut Bencher) {
     let db = env.open_db(None).unwrap();
 
     let mut items: Vec<(String, String)> = (0..n).map(|n| (get_key(n), get_data(n))).collect();
-    XorShiftRng::new_unseeded().shuffle(&mut items[..]);
+    items.shuffle(&mut rand::rngs::StdRng::from_entropy());
 
     b.iter(|| {
         let mut txn = env.begin_rw_txn(None).unwrap();
@@ -104,7 +102,7 @@ fn bench_put_rand_raw(b: &mut Bencher) {
     let db = _env.open_db(None).unwrap();
 
     let mut items: Vec<(String, String)> = (0..n).map(|n| (get_key(n), get_data(n))).collect();
-    XorShiftRng::new_unseeded().shuffle(&mut items[..]);
+    items.shuffle(&mut rand::rngs::StdRng::from_entropy());
 
     let dbi = db.dbi();
     let env = _env.env();

--- a/benches/transaction.rs
+++ b/benches/transaction.rs
@@ -15,7 +15,6 @@ use lmdb::{
     WriteFlags,
 };
 use rand::{
-    Rng,
     XorShiftRng,
 };
 use std::ptr;
@@ -90,7 +89,7 @@ fn bench_put_rand(b: &mut Bencher) {
     XorShiftRng::new_unseeded().shuffle(&mut items[..]);
 
     b.iter(|| {
-        let mut txn = env.begin_rw_txn().unwrap();
+        let mut txn = env.begin_rw_txn(None).unwrap();
         for &(ref key, ref data) in items.iter() {
             txn.put(db, key, data, WriteFlags::empty()).unwrap();
         }

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -22,7 +22,7 @@ pub fn setup_bench_db(num_rows: u32) -> (TempDir, Environment) {
 
     {
         let db = env.open_db(None).unwrap();
-        let mut txn = env.begin_rw_txn().unwrap();
+        let mut txn = env.begin_rw_txn(None).unwrap();
         for i in 0..num_rows {
             txn.put(db, &get_key(i), &get_data(i), WriteFlags::empty()).unwrap();
         }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -343,7 +343,7 @@ mod test {
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
-        let mut txn = env.begin_rw_txn().unwrap();
+        let mut txn = env.begin_rw_txn(None).unwrap();
         txn.put(db, b"key1", b"val1", WriteFlags::empty()).unwrap();
         txn.put(db, b"key2", b"val2", WriteFlags::empty()).unwrap();
         txn.put(db, b"key3", b"val3", WriteFlags::empty()).unwrap();
@@ -365,7 +365,7 @@ mod test {
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
 
-        let mut txn = env.begin_rw_txn().unwrap();
+        let mut txn = env.begin_rw_txn(None).unwrap();
         txn.put(db, b"key1", b"val1", WriteFlags::empty()).unwrap();
         txn.put(db, b"key1", b"val2", WriteFlags::empty()).unwrap();
         txn.put(db, b"key1", b"val3", WriteFlags::empty()).unwrap();
@@ -400,7 +400,7 @@ mod test {
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT | DatabaseFlags::DUP_FIXED).unwrap();
 
-        let mut txn = env.begin_rw_txn().unwrap();
+        let mut txn = env.begin_rw_txn(None).unwrap();
         txn.put(db, b"key1", b"val1", WriteFlags::empty()).unwrap();
         txn.put(db, b"key1", b"val2", WriteFlags::empty()).unwrap();
         txn.put(db, b"key1", b"val3", WriteFlags::empty()).unwrap();
@@ -424,7 +424,7 @@ mod test {
             vec![(b"key1", b"val1"), (b"key2", b"val2"), (b"key3", b"val3"), (b"key5", b"val5")];
 
         {
-            let mut txn = env.begin_rw_txn().unwrap();
+            let mut txn = env.begin_rw_txn(None).unwrap();
             for &(ref key, ref data) in &items {
                 txn.put(db, key, data, WriteFlags::empty()).unwrap();
             }
@@ -542,7 +542,7 @@ mod test {
         ];
 
         {
-            let mut txn = env.begin_rw_txn().unwrap();
+            let mut txn = env.begin_rw_txn(None).unwrap();
             for &(ref key, ref data) in &items {
                 txn.put(db, key, data, WriteFlags::empty()).unwrap();
             }
@@ -576,14 +576,14 @@ mod test {
         }
 
         {
-            let mut txn = env.begin_rw_txn().unwrap();
+            let mut txn = env.begin_rw_txn(None).unwrap();
             for &(ref key, ref data) in &items {
                 txn.put(db, key, data, WriteFlags::empty()).unwrap();
             }
             txn.commit().unwrap();
         }
 
-        let mut txn = env.begin_rw_txn().unwrap();
+        let mut txn = env.begin_rw_txn(None).unwrap();
 
         let cursor = txn.open_rw_cursor(db).unwrap();
         assert_eq!(
@@ -604,7 +604,7 @@ mod test {
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
-        let mut txn = env.begin_rw_txn().unwrap();
+        let mut txn = env.begin_rw_txn(None).unwrap();
         let mut cursor = txn.open_rw_cursor(db).unwrap();
 
         cursor.put(b"key1", b"val1", WriteFlags::empty()).unwrap();

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -924,7 +924,7 @@ mod test {
         assert_eq!(initial_map_size, map_size);
 
         // generate small random values with a predefined target size that surpasses the current map size
-        let data = create_random_data_map_with_target_byte_size(initial_map_size * 2, 5, 10);
+        let data = create_random_data_map_with_target_byte_size(initial_map_size, 5, 10);
 
         // write many key/val values, and while they're being written, expect that database map will grow
         for (key, val) in &data {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -976,7 +976,7 @@ mod test {
 
         rm_rf::ensure_removed("test_resize1").unwrap();
         let dir = TempDir::new("test_resize1").unwrap();
-        let initial_map_size = 1 << 15;
+        let initial_map_size = 1 << 12;
         let env = Environment::new()
             .set_map_size(initial_map_size)
             .set_resize_callback(Some(resize_callback))
@@ -985,13 +985,8 @@ mod test {
             .unwrap();
         let db = env.create_db(None, DatabaseFlags::default()).unwrap();
 
-        let info = env.info().unwrap();
-        let map_size = info.map_size();
-
-        assert_eq!(initial_map_size, map_size);
-
         // generate small random values with a predefined target size that surpasses the current map size
-        let data = create_random_data_map_with_target_byte_size(initial_map_size * 2, 2, 5);
+        let data = create_random_data_map_with_target_byte_size(initial_map_size * 64, 2, 5);
 
         let mut write_resize_count = 0;
         let mut commit_resize_count = 0;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -612,6 +612,7 @@ impl EnvironmentBuilder {
 
     /// The settings that control when and how resize happens
     pub fn set_resize_settings(mut self, settings: DatabaseResizeSettings) -> EnvironmentBuilder {
+        settings.validate();
         self.resize_settings = Some(settings);
         self
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -62,6 +62,7 @@ pub struct Environment {
     env: *mut ffi::MDB_env,
     tx_count: AtomicU32,
     tx_blocker_count: AtomicU32,
+    db_resize_lock: Mutex<()>,
     dbi_open_mutex: Mutex<()>,
 }
 
@@ -166,6 +167,7 @@ impl Environment {
     /// Create a read-write transaction for use with the environment. This method will block while
     /// there are any other read-write transactions open on the environment.
     pub fn begin_rw_txn<'env>(&'env self, headroom: Option<usize>) -> Result<RwTransaction<'env>> {
+        let _lock = self.db_resize_lock.lock().expect("Database resize mutex lock failed");
         self.resize_db_if_necessary(headroom)?;
         RwTransaction::new(self)
     }
@@ -523,6 +525,7 @@ impl EnvironmentBuilder {
             env,
             tx_count: AtomicU32::new(0),
             tx_blocker_count: AtomicU32::new(0),
+            db_resize_lock: Mutex::new(()),
             dbi_open_mutex: Mutex::new(()),
         })
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -296,8 +296,6 @@ impl Environment {
     /// 1. The headroom + currently used size don't fit in map_size()
     /// 2. More than RESIZE_PERCENTage is used of the database
     fn needs_resize(&self, headroom: Option<usize>) -> Result<bool> {
-        // TODO(Sam): test resize checking
-
         let stat = self.stat()?;
         let env_info = self.info()?;
 
@@ -324,8 +322,6 @@ impl Environment {
     /// Keep in mind that a single resize step cannot be larger than 1 << 31, due to usize limitations
     /// this is due to the FFI using usize while lmdb uses mdb_size_t, which is always u64
     fn do_resize(&self, increase_size: usize) -> Result<()> {
-        // TODO(Sam): test resizing
-
         let resize_settings = self.resize_settings.as_ref().unwrap_or(&DEFAULT_RESIZE_SETTINGS);
         let increase_size = increase_size.clamp(resize_settings.min_resize_step, resize_settings.min_resize_step);
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -343,7 +343,7 @@ impl Environment {
         let resize_settings = self.resize_settings.as_ref().unwrap_or(&DEFAULT_RESIZE_SETTINGS);
         let increase_size = increase_size
             .unwrap_or_else(|| Self::headroom_from_ratio(old_map_size, resize_settings.default_resize_ratio_percentage));
-        let increase_size = increase_size.clamp(resize_settings.min_resize_step, resize_settings.min_resize_step);
+        let increase_size = increase_size.clamp(resize_settings.min_resize_step, resize_settings.max_resize_step);
 
         let current_occupied_ratio = Self::map_occupied_size_inner(&env_info, &stat);
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -901,15 +901,15 @@ mod test {
         let resize_callback = Box::new(move |v| resize_actions.lock().unwrap().push(v));
 
         let resize_settings = DatabaseResizeSettings {
-            min_resize_step: 1 << 20,
+            min_resize_step: 1 << 19,
             max_resize_step: 1 << 21,
-            default_resize_step: 1 << 20,
+            default_resize_step: 1 << 19,
             resize_trigger_percentage: 0.9,
         };
 
         rm_rf::ensure_removed("test_resize1").unwrap();
         let dir = TempDir::new("test_resize1").unwrap();
-        let initial_map_size = 1 << 20;
+        let initial_map_size = 1 << 19;
         let env = Environment::new()
             .set_map_size(initial_map_size)
             .set_resize_callback(Some(resize_callback))

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -986,7 +986,7 @@ mod test {
         let db = env.create_db(None, DatabaseFlags::default()).unwrap();
 
         // generate small random values with a predefined target size that surpasses the current map size
-        let data = create_random_data_map_with_target_byte_size(initial_map_size * 1024, 2, 5);
+        let data = create_random_data_map_with_target_byte_size(initial_map_size * 256, 2, 5);
 
         let mut write_resize_count = 0;
         let mut commit_resize_count = 0;
@@ -999,6 +999,7 @@ mod test {
                     Ok(_) => (), // Success in writing value, let's continue to commit
                     Err(e) => match e {
                         Error::MapFull => {
+                            println!("Resizing on write...");
                             write_resize_count += 1;
                             drop(rw_tx);
                             env.do_resize(None).unwrap();
@@ -1012,6 +1013,7 @@ mod test {
                     Ok(_) => break, // Success in committing value, we can exit the inner loop
                     Err(e) => match e {
                         Error::MapFull => {
+                            println!("Resizing on commit...");
                             commit_resize_count += 1;
                             env.do_resize(None).unwrap();
                         },

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -154,7 +154,7 @@ impl Environment {
             if current_iteration_increase >= remaining_required_space {
                 break;
             } else {
-                remaining_required_space -= headroom.unwrap_or(DEFAULT_RESIZE_VALUE);
+                remaining_required_space -= current_iteration_increase;
             }
         }
         Ok(())

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -335,7 +335,7 @@ impl Environment {
 
         // calculate new map size, and ensure it's an integer of OS page size
         let new_map_size = old_map_size.checked_add(increase_size).expect("LMDB resize size addition failed");
-        let new_map_size = new_map_size + stat.page_size() as usize;
+        let new_map_size = new_map_size + new_map_size % stat.page_size() as usize;
 
         let _tx_blocker = ScopedTransactionBlocker::new(self);
         TransactionGuard::wait_for_transactions_to_finish(self);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -986,7 +986,7 @@ mod test {
         let db = env.create_db(None, DatabaseFlags::default()).unwrap();
 
         // generate small random values with a predefined target size that surpasses the current map size
-        let data = create_random_data_map_with_target_byte_size(initial_map_size * 1024, 100, 10000);
+        let data = create_random_data_map_with_target_byte_size(initial_map_size * 1024, 2, 5);
 
         let mut write_resize_count = 0;
         let mut commit_resize_count = 0;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -338,8 +338,15 @@ impl Environment {
 
         // Check available disk space
         let free_space = fs4::free_space(&self.db_path).expect("Failed to get remaining disk space for db resize");
-        let final_increase = new_map_size.checked_sub(old_map_size).expect("Resize invariant broken: new_map_size < old_map_size") as u64;
-        assert!(free_space < final_increase, "LMDB Database resize failed. Available free disk space {} bytes is not big enough; required: {} bytes", free_space, final_increase);
+        let final_increase = new_map_size
+            .checked_sub(old_map_size)
+            .expect("Resize invariant broken: new_map_size < old_map_size") as u64;
+        assert!(
+            free_space < final_increase,
+            "LMDB Database resize failed. Available free disk space {} bytes is not big enough; required: {} bytes",
+            free_space,
+            final_increase
+        );
 
         let _tx_blocker = ScopedTransactionBlocker::new(self);
         TransactionGuard::wait_for_transactions_to_finish(self);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -986,7 +986,7 @@ mod test {
         let db = env.create_db(None, DatabaseFlags::default()).unwrap();
 
         // generate small random values with a predefined target size that surpasses the current map size
-        let data = create_random_data_map_with_target_byte_size(initial_map_size * 64, 2, 5);
+        let data = create_random_data_map_with_target_byte_size(initial_map_size * 1024, 100, 10000);
 
         let mut write_resize_count = 0;
         let mut commit_resize_count = 0;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -838,7 +838,7 @@ mod test {
         let env = Environment::new()
             .set_map_size(initial_map_size)
             .set_resize_callback(Some(resize_callback))
-            .set_resize_settings(resize_settings)
+            .set_resize_settings(resize_settings.clone())
             .open(dir.path())
             .unwrap();
         let db = env.create_db(None, DatabaseFlags::default()).unwrap();
@@ -856,6 +856,12 @@ mod test {
             rw_tx.commit().unwrap();
         }
 
-        assert!(resize_actions_for_check.lock().unwrap().len() > 0);
+        let resize_action_result = resize_actions_for_check.lock().unwrap().clone();
+        assert!(resize_action_result.len() > 0);
+        for act in resize_action_result {
+            assert!(act.old_size < act.new_size);
+            assert!(act.new_size - act.old_size >= resize_settings.min_resize_step as u64);
+            assert!(act.new_size - act.old_size <= resize_settings.max_resize_step as u64);
+        }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -342,7 +342,7 @@ impl Environment {
             .checked_sub(old_map_size)
             .expect("Resize invariant broken: new_map_size < old_map_size") as u64;
         assert!(
-            free_space < final_increase,
+            free_space > final_increase,
             "LMDB Database resize failed. Available free disk space {} bytes is not big enough; required: {} bytes",
             free_space,
             final_increase

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -148,8 +148,9 @@ impl Environment {
     /// Create a read-write transaction for use with the environment. This method will block while
     /// there are any other read-write transactions open on the environment.
     pub fn begin_rw_txn<'env>(&'env self, headroom: Option<usize>) -> Result<RwTransaction<'env>> {
+        const DEFAULT_RESIZE_VALUE: usize = 1 << 28;
         while self.needs_resize(headroom)? {
-            self.do_resize(headroom.unwrap_or(1 << 28))?;
+            self.do_resize(headroom.unwrap_or(DEFAULT_RESIZE_VALUE))?;
         }
         RwTransaction::new(self)
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -134,8 +134,17 @@ impl Environment {
         RoTransaction::new(self)
     }
 
+    fn float_to_usize(val: f64) -> usize {
+        if val > usize::MAX as f64 {
+            panic!("Failed to convert headroom value to usize (MAX hit); this means either database configuration is wrong or an invariant is broken");
+        } else if val < usize::MIN as f64 {
+            panic!("Failed to convert headroom value to usize (MIN hit); this means either database configuration is wrong or an invariant is broken");
+        }
+        val.round() as usize
+    }
+
     fn headroom_from_ratio(current_map_size: usize, resize_ratio: f32) -> usize {
-        (current_map_size as f64 * resize_ratio as f64) as usize
+        Self::float_to_usize(current_map_size as f64 * resize_ratio as f64)
     }
 
     fn resize_db_if_necessary(&self, headroom: Option<usize>) -> Result<()> {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -327,7 +327,7 @@ impl Environment {
     /// and return the new map size.
     /// Keep in mind that a single resize step cannot be larger than 1 << 31, due to usize limitations
     /// this is due to the FFI using usize while lmdb uses mdb_size_t, which is always u64
-    fn do_resize(&self, increase_size: Option<usize>) -> Result<usize> {
+    pub fn do_resize(&self, increase_size: Option<usize>) -> Result<usize> {
         let resize_settings = self.resize_settings.as_ref().unwrap_or(&DEFAULT_RESIZE_SETTINGS);
         let increase_size = increase_size.unwrap_or(resize_settings.default_resize_step);
         let increase_size = increase_size.clamp(resize_settings.min_resize_step, resize_settings.min_resize_step);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -148,10 +148,10 @@ impl Environment {
     fn resize_db_if_necessary(&self, headroom: Option<usize>) -> Result<()> {
         const DEFAULT_RESIZE_VALUE: usize = 1 << 28;
         let mut remaining_required_space = headroom.unwrap_or(DEFAULT_RESIZE_VALUE);
-        let target_headroom = headroom.unwrap_or(DEFAULT_RESIZE_VALUE);
+        let current_iteration_increase = headroom.unwrap_or(DEFAULT_RESIZE_VALUE);
         while self.needs_resize(headroom)? {
-            self.do_resize(remaining_required_space)?;
-            if remaining_required_space <= target_headroom {
+            self.do_resize(current_iteration_increase)?;
+            if current_iteration_increase >= remaining_required_space {
                 break;
             } else {
                 remaining_required_space -= headroom.unwrap_or(DEFAULT_RESIZE_VALUE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ mod error;
 mod flags;
 mod transaction;
 mod transaction_guard;
+mod resize;
 
 #[cfg(test)]
 mod test_utils {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,12 +58,16 @@ macro_rules! lmdb_try_with_cleanup {
     }};
 }
 
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("Mintlayer with lmdb backend can only be compiled on 64-bit systems. Either seek an alternative storage backend or use a 64-bit system.");
+
 mod cursor;
 mod database;
 mod environment;
 mod error;
 mod flags;
 mod transaction;
+mod transaction_guard;
 
 #[cfg(test)]
 mod test_utils {
@@ -96,7 +100,7 @@ mod test_utils {
         for height in 0..1000 {
             let mut value = [0u8; 8];
             LittleEndian::write_u64(&mut value, height);
-            let mut tx = env.begin_rw_txn().expect("begin_rw_txn");
+            let mut tx = env.begin_rw_txn(None).expect("begin_rw_txn");
             tx.put(index, &HEIGHT_KEY, &value, WriteFlags::empty()).expect("tx.put");
             tx.commit().expect("tx.commit")
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,11 @@ mod test_utils {
 
         let dir = TempDir::new("test").unwrap();
 
-        let env = {
-            let mut builder = Environment::new();
-            builder.set_max_dbs(2);
-            builder.set_map_size(1_000_000);
-            builder.open(dir.path()).expect("open lmdb env")
-        };
+        let env = Environment::new().
+        set_max_dbs(2).
+        set_map_size(1_000_000).
+        open(dir.path()).expect("open lmdb env");
+
         let index = env.create_db(None, DatabaseFlags::DUP_SORT).expect("open index db");
 
         for height in 0..1000 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod test_utils {
     use super::*;
 
     /// Regression test for https://github.com/danburkert/lmdb-rs/issues/21.
-    /// This test reliably segfaults when run against lmbdb compiled with opt level -O3 and newer
+    /// This test reliably segfaults when run against lmdb compiled with opt level -O3 and newer
     /// GCC compilers.
     #[test]
     fn issue_21_regression() {

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -8,7 +8,7 @@ pub struct DatabaseResizeInfo {
 
 const DEFAULT_MIN_MAP_SIZE_INCREASE: usize = 1 << 28; // 256 MB
 const DEFAULT_MAX_MAP_SIZE_INCREASE: usize = 1 << 31; // 2 GB
-const DEFAULT_RESIZE_RATIO: f32 = 1.; // double the current storage
+const DEFAULT_RESIZE_RATIO: u32 = 100; // 100%, double the current storage
 const DEFAULT_RESIZE_PERCENT: f32 = 0.9; // 90% full, causes resize
 
 /// Settings that control resizing the database
@@ -19,7 +19,8 @@ pub struct DatabaseResizeSettings {
     /// The maximum amount to increase the size of the database by
     pub max_resize_step: usize,
     /// When a resize is needed and no size is provided, this will be the size ratio to be added compared to the previous size
-    pub default_resize_ratio: f32,
+    /// 100 means 100%, which will double the map size
+    pub default_resize_ratio_percentage: u32,
     /// When current_size/total_size crosses this percentage, a resize will be triggered. Value should be in the range: [0, 1]
     pub resize_trigger_percentage: f32,
 }
@@ -35,7 +36,7 @@ impl DatabaseResizeSettings {
         Self {
             min_resize_step: DEFAULT_MIN_MAP_SIZE_INCREASE,
             max_resize_step: DEFAULT_MAX_MAP_SIZE_INCREASE,
-            default_resize_ratio: DEFAULT_RESIZE_RATIO,
+            default_resize_ratio_percentage: DEFAULT_RESIZE_RATIO,
             resize_trigger_percentage: DEFAULT_RESIZE_PERCENT,
         }
     }
@@ -45,7 +46,7 @@ impl DatabaseResizeSettings {
             panic!("lmdb: Min step must be <= max step")
         }
 
-        if self.default_resize_ratio <= 0. {
+        if self.default_resize_ratio_percentage <= 0 {
             panic!("lmdb: Resize ratio must be > 0");
         }
 

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -39,6 +39,20 @@ impl DatabaseResizeSettings {
             resize_trigger_percentage: DEFAULT_RESIZE_PERCENT,
         }
     }
+
+    pub fn validate(&self) {
+        if self.min_resize_step > self.max_resize_step {
+            panic!("lmdb: Min step must be <= max step")
+        }
+
+        if self.default_resize_step <= 0 {
+            panic!("lmdb: Resize ratio must be > 0");
+        }
+
+        if self.resize_trigger_percentage < 0. {
+            panic!("lmdb: Resize trigger percentage must be >=0 ");
+        }
+    }
 }
 
 pub const DEFAULT_RESIZE_SETTINGS: DatabaseResizeSettings = DatabaseResizeSettings::make_default();

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -6,10 +6,10 @@ pub struct DatabaseResizeInfo {
     pub occupied_size_before_resize: u64,
 }
 
-const DEFAULT_MIN_MAP_SIZE_INCREASE: usize = 1 << 28;
-const DEFAULT_MAX_MAP_SIZE_INCREASE: usize = 1 << 31;
-const DEFAULT_RESIZE_VALUE: usize = 1 << 30;
-const DEFAULT_RESIZE_PERCENT: f32 = 0.9;
+const DEFAULT_MIN_MAP_SIZE_INCREASE: usize = 1 << 28; // 256 MB
+const DEFAULT_MAX_MAP_SIZE_INCREASE: usize = 1 << 31; // 2 GB
+const DEFAULT_RESIZE_RATIO: f32 = 1.; // double the current storage
+const DEFAULT_RESIZE_PERCENT: f32 = 0.9; // 90% full, causes resize
 
 /// Settings that control resizing the database
 #[derive(Debug, Clone)]
@@ -18,8 +18,8 @@ pub struct DatabaseResizeSettings {
     pub min_resize_step: usize,
     /// The maximum amount to increase the size of the database by
     pub max_resize_step: usize,
-    /// When a resize is needed and no size is provided, this will be the size to increase by
-    pub default_resize_step: usize,
+    /// When a resize is needed and no size is provided, this will be the size ratio to be added compared to the previous size
+    pub default_resize_ratio: f32,
     /// When current_size/total_size crosses this percentage, a resize will be triggered. Value should be in the range: [0, 1]
     pub resize_trigger_percentage: f32,
 }
@@ -35,7 +35,7 @@ impl DatabaseResizeSettings {
         Self {
             min_resize_step: DEFAULT_MIN_MAP_SIZE_INCREASE,
             max_resize_step: DEFAULT_MAX_MAP_SIZE_INCREASE,
-            default_resize_step: DEFAULT_RESIZE_VALUE,
+            default_resize_ratio: DEFAULT_RESIZE_RATIO,
             resize_trigger_percentage: DEFAULT_RESIZE_PERCENT,
         }
     }
@@ -45,7 +45,7 @@ impl DatabaseResizeSettings {
             panic!("lmdb: Min step must be <= max step")
         }
 
-        if self.default_resize_step <= 0 {
+        if self.default_resize_ratio <= 0. {
             panic!("lmdb: Resize ratio must be > 0");
         }
 

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -8,7 +8,7 @@ pub struct DatabaseResizeInfo {
 
 const DEFAULT_MIN_MAP_SIZE_INCREASE: usize = 1 << 28;
 const DEFAULT_MAX_MAP_SIZE_INCREASE: usize = 1 << 31;
-const DEFAULT_RESIZE_VALUE: usize = 1 << 28;
+const DEFAULT_RESIZE_VALUE: usize = 1 << 30;
 const DEFAULT_RESIZE_PERCENT: f32 = 0.9;
 
 /// Settings that control resizing the database

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -1,4 +1,5 @@
 /// The information that will be sent in a callback when a resize happens
+#[derive(Debug, Clone)]
 pub struct DatabaseResizeInfo {
     pub old_size: u64,
     pub new_size: u64,

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -3,6 +3,7 @@
 pub struct DatabaseResizeInfo {
     pub old_size: u64,
     pub new_size: u64,
+    pub occupied_size_before_resize: u64,
 }
 
 const DEFAULT_MIN_MAP_SIZE_INCREASE: usize = 1 << 28;

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -1,0 +1,42 @@
+/// The information that will be sent in a callback when a resize happens
+pub struct DatabaseResizeInfo {
+    pub old_size: u64,
+    pub new_size: u64,
+}
+
+const DEFAULT_MIN_MAP_SIZE_INCREASE: usize = 1 << 28;
+const DEFAULT_MAX_MAP_SIZE_INCREASE: usize = 1 << 31;
+const DEFAULT_RESIZE_VALUE: usize = 1 << 28;
+const DEFAULT_RESIZE_PERCENT: f32 = 0.9;
+
+/// Settings that control resizing the database
+#[derive(Debug, Clone)]
+pub struct DatabaseResizeSettings {
+    /// The minimum amount to increase the size of the database by
+    pub min_resize_step: usize,
+    /// The maximum amount to increase the size of the database by
+    pub max_resize_step: usize,
+    /// When a resize is needed and no size is provided, this will be the size to increase by
+    pub default_resize_step: usize,
+    /// When current_size/total_size crosses this percentage, a resize will be triggered. Value should be in the range: [0, 1]
+    pub resize_trigger_percentage: f32,
+}
+
+impl Default for DatabaseResizeSettings {
+    fn default() -> Self {
+        Self::make_default()
+    }
+}
+
+impl DatabaseResizeSettings {
+    const fn make_default() -> Self {
+        Self {
+            min_resize_step: DEFAULT_MIN_MAP_SIZE_INCREASE,
+            max_resize_step: DEFAULT_MAX_MAP_SIZE_INCREASE,
+            default_resize_step: DEFAULT_RESIZE_VALUE,
+            resize_trigger_percentage: DEFAULT_RESIZE_PERCENT,
+        }
+    }
+}
+
+pub const DEFAULT_RESIZE_SETTINGS: DatabaseResizeSettings = DatabaseResizeSettings::make_default();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,38 +1,14 @@
-use libc::{
-    c_uint,
-    c_void,
-    size_t,
-};
+use libc::{c_uint, c_void, size_t};
 use std::marker::PhantomData;
-use std::{
-    fmt,
-    mem,
-    ptr,
-    result,
-    slice,
-};
+use std::{fmt, mem, ptr, result, slice};
 
 use ffi;
 
-use cursor::{
-    RoCursor,
-    RwCursor,
-};
+use cursor::{RoCursor, RwCursor};
 use database::Database;
-use environment::{
-    Environment,
-    Stat,
-};
-use error::{
-    lmdb_result,
-    Error,
-    Result,
-};
-use flags::{
-    DatabaseFlags,
-    EnvironmentFlags,
-    WriteFlags,
-};
+use environment::{Environment, Stat};
+use error::{lmdb_result, Error, Result};
+use flags::{DatabaseFlags, EnvironmentFlags, WriteFlags};
 
 use crate::transaction::private::TransactionSealedProps;
 use crate::transaction_guard::TransactionGuard;
@@ -473,14 +449,8 @@ impl<'env> private::TransactionSealedProps for RwTransaction<'env> {
 mod test {
 
     use std::io::Write;
-    use std::sync::{
-        Arc,
-        Barrier,
-    };
-    use std::thread::{
-        self,
-        JoinHandle,
-    };
+    use std::sync::{Arc, Barrier};
+    use std::thread::{self, JoinHandle};
 
     use tempdir::TempDir;
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -441,7 +441,7 @@ impl<'env> private::TransactionSealedProps for RwTransaction<'env> {
     }
 
     fn is_nullified(&self) -> bool {
-        self.txn == std::ptr::null_mut()
+        self.txn.is_null()
     }
 }
 

--- a/src/transaction_guard.rs
+++ b/src/transaction_guard.rs
@@ -12,7 +12,7 @@ pub struct TransactionGuard<'a> {
 impl<'a> TransactionGuard<'a> {
     pub fn new(env: &'a Environment) -> Self {
         // ensure races won't happen in this scope
-        SpinLock::new(env.tx_blocker_spinlock());
+        let _lock = SpinLock::new(env.tx_blocker_spinlock());
 
         ScopedTransactionBlocker::wait_for_all_blockers(env);
         env.tx_count().fetch_add(1, Ordering::Relaxed);
@@ -58,6 +58,7 @@ impl<'a> Drop for ScopedTransactionBlocker<'a> {
     }
 }
 
+#[must_use = "TransactionGuard has no effect without holding its object"]
 struct SpinLock<'a> {
     lock: &'a AtomicBool,
 }

--- a/src/transaction_guard.rs
+++ b/src/transaction_guard.rs
@@ -79,5 +79,3 @@ impl<'a> Drop for SpinLock<'a> {
         self.lock.store(false, Ordering::Release);
     }
 }
-
-// TODO(Sam): tests

--- a/src/transaction_guard.rs
+++ b/src/transaction_guard.rs
@@ -1,0 +1,62 @@
+use std::{
+    marker::PhantomData,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+static TRANSACTION_COUNT: AtomicU32 = AtomicU32::new(0);
+static TRANSACTIONS_BLOCKERS: AtomicU32 = AtomicU32::new(0);
+
+#[must_use = "TransactionGuard has no effect without holding its object"]
+pub struct TransactionGuard {
+    private: PhantomData<()>,
+}
+
+/// A transaction guard is a static global counter that keeps track of all transactions currently open
+/// It can be used for operations that need to wait for all transactions to be closed, such as map-resize
+impl TransactionGuard {
+    pub fn new() -> Self {
+        ScopedTransactionBlocker::wait_for_all_blockers();
+        TRANSACTION_COUNT.fetch_add(1, Ordering::Relaxed);
+        Self {
+            private: Default::default(),
+        }
+    }
+
+    pub fn wait_for_transactions_to_finish() {
+        while TRANSACTION_COUNT.load(Ordering::Relaxed) > 0 {}
+    }
+}
+
+impl Drop for TransactionGuard {
+    fn drop(&mut self) {
+        TRANSACTION_COUNT.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[must_use = "ScopedTransactionBlocker has no effect without holding its object"]
+pub struct ScopedTransactionBlocker {
+    private: PhantomData<()>,
+}
+
+/// A ScopedTransactionBlocked is a struct that is used to prevent new transactions from being created
+/// As long as an instance is alive, TransactionGuard will prevent the creation of new transactions
+impl ScopedTransactionBlocker {
+    pub fn new() -> Self {
+        TRANSACTIONS_BLOCKERS.fetch_add(1, Ordering::Relaxed);
+        Self {
+            private: Default::default(),
+        }
+    }
+
+    pub fn wait_for_all_blockers() {
+        while TRANSACTIONS_BLOCKERS.load(Ordering::Relaxed) > 0 {}
+    }
+}
+
+impl Drop for ScopedTransactionBlocker {
+    fn drop(&mut self) {
+        TRANSACTIONS_BLOCKERS.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+// TODO(Sam): tests

--- a/src/transaction_guard.rs
+++ b/src/transaction_guard.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::Environment;
 
@@ -11,6 +11,9 @@ pub struct TransactionGuard<'a> {
 /// It can be used for operations that need to wait for all transactions to be closed, such as map-resize
 impl<'a> TransactionGuard<'a> {
     pub fn new(env: &'a Environment) -> Self {
+        // ensure races won't happen in this scope
+        SpinLock::new(env.tx_blocker_spinlock());
+
         ScopedTransactionBlocker::wait_for_all_blockers(env);
         env.tx_count().fetch_add(1, Ordering::Relaxed);
         Self {
@@ -52,6 +55,28 @@ impl<'a> ScopedTransactionBlocker<'a> {
 impl<'a> Drop for ScopedTransactionBlocker<'a> {
     fn drop(&mut self) {
         self.env.tx_blocker_count().fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+struct SpinLock<'a> {
+    lock: &'a AtomicBool,
+}
+
+impl<'a> SpinLock<'a> {
+    fn new(lock: &'a AtomicBool) -> SpinLock {
+        while lock.compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed).unwrap_or(true) {
+            std::thread::yield_now();
+        }
+
+        SpinLock {
+            lock,
+        }
+    }
+}
+
+impl<'a> Drop for SpinLock<'a> {
+    fn drop(&mut self) {
+        self.lock.store(false, Ordering::Release);
     }
 }
 

--- a/src/transaction_guard.rs
+++ b/src/transaction_guard.rs
@@ -1,61 +1,57 @@
-use std::{
-    marker::PhantomData,
-    sync::atomic::{AtomicU32, Ordering},
-};
+use std::sync::atomic::Ordering;
 
-static TRANSACTION_COUNT: AtomicU32 = AtomicU32::new(0);
-static TRANSACTIONS_BLOCKERS: AtomicU32 = AtomicU32::new(0);
+use crate::Environment;
 
 #[must_use = "TransactionGuard has no effect without holding its object"]
-pub struct TransactionGuard {
-    private: PhantomData<()>,
+pub struct TransactionGuard<'a> {
+    env: &'a Environment,
 }
 
 /// A transaction guard is a static global counter that keeps track of all transactions currently open
 /// It can be used for operations that need to wait for all transactions to be closed, such as map-resize
-impl TransactionGuard {
-    pub fn new() -> Self {
-        ScopedTransactionBlocker::wait_for_all_blockers();
-        TRANSACTION_COUNT.fetch_add(1, Ordering::Relaxed);
+impl<'a> TransactionGuard<'a> {
+    pub fn new(env: &'a Environment) -> Self {
+        ScopedTransactionBlocker::wait_for_all_blockers(env);
+        env.tx_count().fetch_add(1, Ordering::Relaxed);
         Self {
-            private: Default::default(),
+            env,
         }
     }
 
-    pub fn wait_for_transactions_to_finish() {
-        while TRANSACTION_COUNT.load(Ordering::Relaxed) > 0 {}
+    pub fn wait_for_transactions_to_finish(env: &'a Environment) {
+        while env.tx_count().load(Ordering::Relaxed) > 0 {}
     }
 }
 
-impl Drop for TransactionGuard {
+impl<'a> Drop for TransactionGuard<'a> {
     fn drop(&mut self) {
-        TRANSACTION_COUNT.fetch_sub(1, Ordering::Relaxed);
+        self.env.tx_count().fetch_sub(1, Ordering::Relaxed);
     }
 }
 
 #[must_use = "ScopedTransactionBlocker has no effect without holding its object"]
-pub struct ScopedTransactionBlocker {
-    private: PhantomData<()>,
+pub struct ScopedTransactionBlocker<'a> {
+    env: &'a Environment,
 }
 
 /// A ScopedTransactionBlocked is a struct that is used to prevent new transactions from being created
 /// As long as an instance is alive, TransactionGuard will prevent the creation of new transactions
-impl ScopedTransactionBlocker {
-    pub fn new() -> Self {
-        TRANSACTIONS_BLOCKERS.fetch_add(1, Ordering::Relaxed);
+impl<'a> ScopedTransactionBlocker<'a> {
+    pub fn new(env: &'a Environment) -> Self {
+        env.tx_blocker_count().fetch_add(1, Ordering::Relaxed);
         Self {
-            private: Default::default(),
+            env,
         }
     }
 
-    pub fn wait_for_all_blockers() {
-        while TRANSACTIONS_BLOCKERS.load(Ordering::Relaxed) > 0 {}
+    pub fn wait_for_all_blockers(env: &'a Environment) {
+        while env.tx_blocker_count().load(Ordering::Relaxed) > 0 {}
     }
 }
 
-impl Drop for ScopedTransactionBlocker {
+impl<'a> Drop for ScopedTransactionBlocker<'a> {
     fn drop(&mut self) {
-        TRANSACTIONS_BLOCKERS.fetch_sub(1, Ordering::Relaxed);
+        self.env.tx_blocker_count().fetch_sub(1, Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
In this PR, we implement database resizing within lmdb, with zero locking and supposedly thread-safe work based on lmdb's invariants.